### PR TITLE
Use Java 8 to run check pipeline

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 8
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '8'
         distribution: 'adopt'
         cache: maven
     - name: Build with Maven


### PR DESCRIPTION
This will allow checking for stuff incompatible with Java 8 ~~like Apache Lucene 9 for example~~