### PR TITLE
Revert "Bump slf4j-nop from 1.7.36 to 2.0.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
-            <version>2.0.0</version>
+            <version>1.7.36</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Reverts max4805/RandomStuffWebsite#115

This update makes a warning appear... but the whole point of having this dependency is removing the warning.